### PR TITLE
Some more methods for API compatibility 

### DIFF
--- a/lib/HTML/TreeBuilder/LibXML/Node.pm
+++ b/lib/HTML/TreeBuilder/LibXML/Node.pm
@@ -169,6 +169,22 @@ sub childNodes {
     wantarray ? @nodes : \@nodes;
 }
 
+sub left {
+    my $self = shift;
+
+    $self->_eof_or_die unless $self->{node};
+    my $prev = $self->{node}->previousNonBlankSibling;
+    return $prev ? __PACKAGE__->new( $prev ) : undef;
+}
+
+sub right {
+    my $self = shift;
+
+    $self->_eof_or_die unless $self->{node};
+    my $next = $self->{node}->nextNonBlankSibling;
+    return $next ? __PACKAGE__->new( $next ) : undef;
+}
+
 sub look_down {
     my $self = shift;
     my @args = @_;
@@ -252,6 +268,8 @@ HTML::TreeBuilder::LibXML::Node - HTML::Element compatible API for HTML::TreeBui
   my $id     = $node->id;
   my $clone  = $node->clone;
   $node->delete;
+  my $prev_sib = $node->left;
+  my $next_sib = $node->right;
   $node->look_down(@args);
   my %attr     = $node->all_attr;
   my %attr     = $node->all_external_attr;

--- a/t/HTML-TreeBuilder-XPath.t
+++ b/t/HTML-TreeBuilder-XPath.t
@@ -3,7 +3,7 @@
 
 #########################
 
-use Test::More tests => 29;
+use Test::More tests => 31;
 BEGIN { use_ok('HTML::TreeBuilder::XPath') };
 use HTML::TreeBuilder::LibXML;
 HTML::TreeBuilder::LibXML->replace_original;
@@ -89,6 +89,14 @@ is( $children[1]->getValue , 'links' , 'first child');
 {
 my @filter_nodes = $html->findnodes_filter( '//p' , sub { shift->getValue =~ /Intro / } );
 is( scalar @filter_nodes , 3 , '3 <p>' );
+}
+
+{
+my ($div ) = $html->findnodes( '//div[@class="intro"]' );
+my $left = $div->left;
+is( $left->tag , 'h1' );
+my $right = $div->right;
+is( $right->tag , 'p' );
 }
 
 __END__


### PR DESCRIPTION
Adding more methods required for HTML::TreeBuilder::XPath compatibility --
- left and right
- childNodes
- findnodes_filter 

(Last one is somewhat ugly, but only way I could see to allow for conversion of 'findnodes' calls that use regexp-style XPath that is supported by HTML::TreeBuilder::XPath. Would love suggestions of better/nicer ways to do this.)
