### PR TITLE
handle /(de)?objectify_text/ for <script> extraction

### DIFF
--- a/lib/HTML/TreeBuilder/LibXML/Node.pm
+++ b/lib/HTML/TreeBuilder/LibXML/Node.pm
@@ -17,6 +17,8 @@ sub attr {
         } else {
             $self->{node}->removeAttribute(lc $key);
         }
+    } elsif (@_ == 2 and lc $key eq 'text') {
+        return $self->{node}->textContent;
     }
     $self->{node}->getAttribute(lc $key);
 }
@@ -46,6 +48,8 @@ sub as_trimmed_text {
 }
 sub as_text_trimmed { shift->as_trimmed_text(@_) } # alias
 
+sub objectify_text { }
+sub deobjectify_text { }
 
 sub as_XML {
     $_[0]->{node}->toString;
@@ -175,6 +179,8 @@ sub look_down {
             shift @args;
         }
     }
+
+    $xpath =~ s/~text\b/text()/g;
 
     my @nodes = $self->findnodes($xpath);
     my @wants = grep {

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -6,7 +6,7 @@ use Data::Dumper;
 
 my $original_ok = eval 'use HTML::TreeBuilder::XPath; 1';
 
-my $tests = 32;
+my $tests = 34;
 $tests *= 2 if $original_ok;
 plan tests => $tests;
 
@@ -116,6 +116,7 @@ sub _look_down {
         <html>
             <head><title>test</title></head>
             <body>
+            <script>alert("hello world")</script>
             <a href="http://wassr.jp/">wassr</a>
             <div>
                 <a href="http://mixi.jp/">mixi</a>
@@ -142,6 +143,13 @@ sub _look_down {
     {
         my $none = $tree->look_down('_tag' => 'a', sub { 0 });
         ok !defined $none, "none because sub ref returns 0";
+    }
+    {
+        $tree->elementify;
+        $tree->objectify_text;
+        my @nodes = $tree->look_down('_tag' => '~text', sub { $_[0]->attr('text') =~ /alert/ });
+        is scalar(@nodes), 1;
+        is $nodes[0]->attr('text'), 'alert("hello world")';
     }
 
     $tree = $tree->delete;


### PR DESCRIPTION
Many scrapers handle `<script>` data extraction via similar construct:

``` perl
    $self->tree->elementify();
    $self->tree->objectify_text();
    if (my $script = $self->tree->look_down(
            q(_tag) => q(~text),
            sub { $_[0]->attr(q(text)) =~ m/var\saddress/sx }
        )->attr(q(text))
        )
    {
```

This patch makes HTML::TreeBuilder::LibXML compatible with it.
