### PR TITLE
don't have the parser string blanks by default

### DIFF
--- a/lib/HTML/TreeBuilder/LibXML.pm
+++ b/lib/HTML/TreeBuilder/LibXML.pm
@@ -36,7 +36,7 @@ sub _parser {
         $PARSER = XML::LibXML->new();
         $PARSER->recover(1);
         $PARSER->recover_silently(1);
-        $PARSER->keep_blanks(0);
+        $PARSER->keep_blanks(1);
         $PARSER->expand_entities(1);
         $PARSER->no_network(1);
     }

--- a/t/blanks.t
+++ b/t/blanks.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use HTML::TreeBuilder::LibXML;
+
+my $tree = HTML::TreeBuilder::LibXML->new;
+$tree->parse( '<div><l>this</l> <l>that</l></div>' );
+$tree->eof;
+
+is $tree->as_XML, '<html><body><div><l>this</l> <l>that</l></div></body></html>';


### PR DESCRIPTION
As the added test demonstrate, removing those
blanks can mess with documents. Took me a while
to figure out where my <b>this</b> <i>and that</i>
was getting compressed. :-)