### PR TITLE
fallback to toString() when toStringC14N(1) gives an empty string

### DIFF
--- a/lib/HTML/TreeBuilder/LibXML/Node.pm
+++ b/lib/HTML/TreeBuilder/LibXML/Node.pm
@@ -74,7 +74,8 @@ sub as_HTML {
     {
         local $@; # protect existing $@
         my $output = eval { $_[0]->{node}->toStringC14N(1) };
-        return $@ ? $_[0]->{node}->toString : $output;
+        return $_[0]->{node}->toString if ($@ or $output eq '');
+        return $output;
     }
 }
 


### PR DESCRIPTION
With libxml2 2.9.12, toStringC14N(1) gives an empty string when parsing an empty tree. In these cases, it makes more sense to fallback to toString().

Fixes #16 